### PR TITLE
Add auto-upgrade with settings toggle

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"github.com/smallest-inc/velocity-cli/internal/api"
 	"github.com/smallest-inc/velocity-cli/internal/config"
 	"github.com/smallest-inc/velocity-cli/internal/update"
-	"github.com/smallest-inc/velocity-cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -83,14 +82,14 @@ var rootCmd = &cobra.Command{
 			return
 		}
 
-		// Show cached update notification (local file read, zero latency)
-		if msg := update.Notify(version); msg != "" {
-			fmt.Println()
-			ui.Info(msg)
+		// Auto-upgrade: check for new version and silently upgrade after
+		// the user's command completes. Respects a 1h cooldown between checks.
+		// Skipped for dirty/dev builds and when disabled via `vctl settings set auto-upgrade off`.
+		autoUpgradeEnabled := true
+		if cfg != nil {
+			autoUpgradeEnabled = cfg.IsAutoUpgradeEnabled()
 		}
-
-		// Kick off background check for next time (non-blocking)
-		update.CheckInBackground(version)
+		update.AutoUpgrade(version, Quiet, autoUpgradeEnabled)
 	},
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/smallest-inc/velocity-cli/internal/config"
+	"github.com/smallest-inc/velocity-cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var settingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "View and manage CLI settings",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		autoUpgrade := "on (default)"
+		if c.AutoUpgrade != nil {
+			if *c.AutoUpgrade {
+				autoUpgrade = "on"
+			} else {
+				autoUpgrade = "off"
+			}
+		}
+
+		fmt.Printf("  auto-upgrade:  %s\n", autoUpgrade)
+		return nil
+	},
+}
+
+var settingsSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a CLI setting",
+	Long: `Set a CLI setting. Available settings:
+
+  auto-upgrade  on|off   Auto-upgrade vctl after each command (default: on)`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		value := strings.ToLower(args[1])
+
+		c, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		switch key {
+		case "auto-upgrade":
+			switch value {
+			case "on", "true", "1":
+				v := true
+				c.AutoUpgrade = &v
+			case "off", "false", "0":
+				v := false
+				c.AutoUpgrade = &v
+			default:
+				return fmt.Errorf("invalid value %q for auto-upgrade (use on/off)", value)
+			}
+		default:
+			return fmt.Errorf("unknown setting %q (available: auto-upgrade)", key)
+		}
+
+		if err := config.Save(c); err != nil {
+			return fmt.Errorf("failed to save settings: %w", err)
+		}
+
+		ui.Success(fmt.Sprintf("%s = %s", key, value))
+		return nil
+	},
+}
+
+func init() {
+	settingsCmd.AddCommand(settingsSetCmd)
+	rootCmd.AddCommand(settingsCmd)
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"archive/tar"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,22 +11,9 @@ import (
 	"strings"
 
 	"github.com/smallest-inc/velocity-cli/internal/ui"
+	"github.com/smallest-inc/velocity-cli/internal/update"
 	"github.com/spf13/cobra"
 )
-
-const (
-	releaseAPI = "https://api.github.com/repos/smallest-inc/velocity-cli/releases/latest"
-)
-
-type githubRelease struct {
-	TagName string        `json:"tag_name"`
-	Assets  []githubAsset `json:"assets"`
-}
-
-type githubAsset struct {
-	Name               string `json:"name"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
@@ -36,20 +22,10 @@ var upgradeCmd = &cobra.Command{
 		ui.Step(Verbose, "Checking for latest release")
 		stop := ui.Spinner("Checking for updates")
 
-		resp, err := http.Get(releaseAPI)
+		release, err := update.FetchLatestRelease()
 		stop()
 		if err != nil {
 			return fmt.Errorf("failed to check for updates: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("failed to check for updates (HTTP %d)", resp.StatusCode)
-		}
-
-		var release githubRelease
-		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-			return fmt.Errorf("failed to parse release info: %w", err)
 		}
 
 		latestVersion := strings.TrimPrefix(release.TagName, "v")
@@ -60,16 +36,15 @@ var upgradeCmd = &cobra.Command{
 
 		ui.Info(fmt.Sprintf("Current: %s → Latest: %s", version, latestVersion))
 
-		// Find matching asset
-		targetAsset := findAsset(release.Assets)
-		if targetAsset == nil {
+		asset := update.FindAsset(release.Assets)
+		if asset == nil {
 			return fmt.Errorf("no release binary for %s/%s", runtime.GOOS, runtime.GOARCH)
 		}
 
-		ui.Step(Verbose, fmt.Sprintf("Downloading %s", targetAsset.Name))
+		ui.Step(Verbose, fmt.Sprintf("Downloading %s", asset.Name))
 		stop = ui.Spinner(fmt.Sprintf("Downloading %s", latestVersion))
 
-		binResp, err := http.Get(targetAsset.BrowserDownloadURL)
+		binResp, err := http.Get(asset.BrowserDownloadURL)
 		stop()
 		if err != nil {
 			return fmt.Errorf("failed to download: %w", err)
@@ -80,13 +55,11 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("download failed (HTTP %d)", binResp.StatusCode)
 		}
 
-		// Extract binary from tar.gz
 		newBinary, err := extractBinary(binResp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to extract binary: %w", err)
 		}
 
-		// Replace current binary
 		execPath, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("failed to find current binary: %w", err)
@@ -94,7 +67,6 @@ var upgradeCmd = &cobra.Command{
 
 		ui.Step(Verbose, fmt.Sprintf("Replacing %s", execPath))
 
-		// Write to temp file, then rename (atomic on same filesystem)
 		tmpPath := execPath + ".new"
 		if err := os.WriteFile(tmpPath, newBinary, 0755); err != nil {
 			return fmt.Errorf("failed to write new binary: %w", err)
@@ -108,18 +80,6 @@ var upgradeCmd = &cobra.Command{
 		ui.Success(fmt.Sprintf("Upgraded to %s", latestVersion))
 		return nil
 	},
-}
-
-func findAsset(assets []githubAsset) *githubAsset {
-	// Match by OS and arch anywhere in the filename
-	// goreleaser names: vctl_0.1.0_darwin_amd64.tar.gz
-	osArch := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-	for i := range assets {
-		if strings.Contains(assets[i].Name, osArch) && strings.HasSuffix(assets[i].Name, ".tar.gz") {
-			return &assets[i]
-		}
-	}
-	return nil
 }
 
 func extractBinary(r io.Reader) ([]byte, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,15 @@ type Config struct {
 	ProjectDisplayName string `yaml:"project_display_name,omitempty"`
 	InstanceID         string `yaml:"instance_id,omitempty"`
 	InstanceName       string `yaml:"instance_name,omitempty"`
+	AutoUpgrade        *bool  `yaml:"auto_upgrade,omitempty"` // nil = default (on), true = on, false = off
+}
+
+// IsAutoUpgradeEnabled returns true if auto-upgrade is enabled (default: true).
+func (c *Config) IsAutoUpgradeEnabled() bool {
+	if c.AutoUpgrade == nil {
+		return true // default on
+	}
+	return *c.AutoUpgrade
 }
 
 // Credentials stores authentication tokens.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,11 +1,15 @@
 package update
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -14,13 +18,23 @@ import (
 
 const (
 	releaseAPI    = "https://api.github.com/repos/smallest-inc/velocity-cli/releases/latest"
-	checkCooldown = 24 * time.Hour
+	checkCooldown = 1 * time.Hour
 )
 
 type state struct {
 	LastCheck      time.Time `yaml:"last_check"`
 	LatestVersion  string    `yaml:"latest_version"`
 	CurrentVersion string    `yaml:"current_version"`
+}
+
+type GithubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []GithubAsset `json:"assets"`
+}
+
+type GithubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
 func statePath() string {
@@ -43,8 +57,8 @@ func saveState(s *state) {
 	os.WriteFile(statePath(), data, 0644)
 }
 
-// Notify returns an update message if a newer version was previously discovered.
-// This is purely a local file read — zero network, zero latency.
+// Notify returns an update message if a newer version was previously discovered
+// but auto-upgrade hasn't run yet (e.g., upgrade failed or was skipped).
 func Notify(currentVersion string) string {
 	s := loadState()
 	if s.LatestVersion != "" && s.LatestVersion != currentVersion {
@@ -53,47 +67,168 @@ func Notify(currentVersion string) string {
 	return ""
 }
 
-// CheckInBackground spawns a goroutine to check for updates if the cooldown
-// has passed. The result is written to disk for the next invocation to read
-// via Notify(). This never blocks the calling goroutine.
+// AutoUpgrade checks for a new version and silently upgrades in the background.
+// Called in PersistentPostRun — runs after the user's command completes.
+// Returns immediately if the cooldown hasn't passed or no update is available.
+func AutoUpgrade(currentVersion string, quiet bool, enabled bool) {
+	// Skip for local dev builds or when disabled via settings
+	if !enabled || strings.Contains(currentVersion, "dirty") || currentVersion == "dev" {
+		return
+	}
+
+	s := loadState()
+	if time.Since(s.LastCheck) < checkCooldown {
+		// Cooldown not passed — check if we have a cached newer version to apply
+		if s.LatestVersion != "" && s.LatestVersion != currentVersion {
+			doUpgrade(currentVersion, s.LatestVersion, quiet)
+		}
+		return
+	}
+
+	// Cooldown passed — fetch latest and upgrade if needed
+	release, err := FetchLatestRelease()
+	if err != nil {
+		return // silent failure
+	}
+
+	latest := strings.TrimPrefix(release.TagName, "v")
+	saveState(&state{
+		LastCheck:      time.Now(),
+		LatestVersion:  latest,
+		CurrentVersion: currentVersion,
+	})
+
+	if latest != currentVersion {
+		doUpgrade(currentVersion, latest, quiet)
+	}
+}
+
+// CheckInBackground spawns a goroutine to check for updates. The result is
+// written to disk for Notify() or AutoUpgrade() on the next invocation.
 func CheckInBackground(currentVersion string) {
 	s := loadState()
 	if time.Since(s.LastCheck) < checkCooldown {
-		return // cooldown hasn't passed, skip
+		return
 	}
 
 	go func() {
-		latest, err := fetchLatestVersion()
+		release, err := FetchLatestRelease()
 		if err != nil {
-			return // silent failure
+			return
 		}
-		s := &state{
+		saveState(&state{
 			LastCheck:      time.Now(),
-			LatestVersion:  latest,
+			LatestVersion:  strings.TrimPrefix(release.TagName, "v"),
 			CurrentVersion: currentVersion,
-		}
-		saveState(s)
+		})
 	}()
 }
 
-func fetchLatestVersion() (string, error) {
+func doUpgrade(currentVersion, latestVersion string, quiet bool) {
+	release, err := FetchLatestRelease()
+	if err != nil {
+		return
+	}
+
+	asset := FindAsset(release.Assets)
+	if asset == nil {
+		return
+	}
+
+	binary, err := downloadAndExtract(asset.BrowserDownloadURL)
+	if err != nil {
+		return
+	}
+
+	execPath, err := os.Executable()
+	if err != nil {
+		return
+	}
+
+	// Atomic replace: write to temp file, then rename
+	tmpPath := execPath + ".new"
+	if err := os.WriteFile(tmpPath, binary, 0755); err != nil {
+		return
+	}
+
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		os.Remove(tmpPath)
+		return
+	}
+
+	if !quiet {
+		fmt.Printf("\n✓ vctl auto-upgraded: %s → %s\n", currentVersion, latestVersion)
+	}
+
+	// Update state so we don't re-upgrade
+	saveState(&state{
+		LastCheck:      time.Now(),
+		LatestVersion:  latestVersion,
+		CurrentVersion: latestVersion,
+	})
+}
+
+// FetchLatestRelease queries the GitHub API for the latest release.
+func FetchLatestRelease() (*GithubRelease, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(releaseAPI)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
+	var release GithubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
+		return nil, err
+	}
+	return &release, nil
+}
+
+// FindAsset returns the release asset matching the current OS/arch.
+func FindAsset(assets []GithubAsset) *GithubAsset {
+	osArch := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	for i := range assets {
+		if strings.Contains(assets[i].Name, osArch) && strings.HasSuffix(assets[i].Name, ".tar.gz") {
+			return &assets[i]
+		}
+	}
+	return nil
+}
+
+func downloadAndExtract(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
-	return strings.TrimPrefix(release.TagName, "v"), nil
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Name == "vctl" || strings.HasSuffix(hdr.Name, "/vctl") {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("vctl binary not found in archive")
 }


### PR DESCRIPTION
## Summary
Auto-upgrade vctl after every command (1h cooldown). Downloads the latest release binary and replaces in-place. Takes effect on next invocation.

**Skipped for:**
- Local dev builds (`dirty`/`dev` versions) — so you can test without overwrite
- When disabled via `vctl settings set auto-upgrade off`

**New commands:**
- `vctl settings` — view current settings
- `vctl settings set auto-upgrade on|off` — toggle auto-upgrade (persisted to ~/.vctl/config.yml)

## Changes
- `internal/update/update.go` — `AutoUpgrade()` function: check + download + replace
- `cmd/settings.go` — new settings command
- `cmd/root.go` — PersistentPostRun calls AutoUpgrade
- `cmd/upgrade.go` — refactored to use shared helpers from update package
- `internal/config/config.go` — `AutoUpgrade` field + `IsAutoUpgradeEnabled()`

## Test plan
- [x] `vctl auth status` on dirty build → no auto-upgrade
- [x] `vctl auth status` on release build with newer version → auto-upgrades
- [x] `vctl settings set auto-upgrade off` → persists, skips upgrade
- [x] `vctl settings` → shows current state